### PR TITLE
Simplify header regexp

### DIFF
--- a/src/__tests__/headers.test.ts
+++ b/src/__tests__/headers.test.ts
@@ -41,6 +41,12 @@ describe('parse header', () => {
         expect(parsedHeaders.length).toBe(1);
         expect(parsedHeaders[0].parameters).toBeUndefined();
     });
+    it('should "special" characters in header value', () => {
+        const headerLine = 'Route: Alice <sip:*888(23)~3!me@atlanta.com>';
+        const parsedHeaders = parseHeaderLine(headerLine);
+        expect(parsedHeaders.length).toBe(1);
+        expect(parsedHeaders[0].fieldValue).toBe('Alice <sip:*888(23)~3!me@atlanta.com>');
+    });
     it('should allow parameters in headers', () => {
         const headerLine = 'From: "Bob" <sips:bob@biloxi.com> ;tag=a48s';
         const parsedHeaders = parseHeaderLine(headerLine);

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -40,7 +40,7 @@ function matchHeaderLine(headerLine: string) {
     // Returns two groups:
     // 1. Header name
     // 2. All values that come after the colon
-    return headerLine.match(/([A-Za-z-]+):([\w\s\-;,=~<>!@:./"]+)/);
+    return headerLine.match(/([A-Za-z-]+):(.+)/);
 }
 
 function splitFieldValueAndParams(headerValue: string): string[] {


### PR DESCRIPTION
This PR simplifies the RegExp describing the header name-value pair.

Closes #9 