### PR TITLE
feat: parse quoted headers correctly

### DIFF
--- a/src/__tests__/headers.test.ts
+++ b/src/__tests__/headers.test.ts
@@ -35,6 +35,15 @@ describe('parse header', () => {
         expect(parsedHeaders[0].fieldValue).toBe('<sip:alice@atlanta.com>');
         expect(parsedHeaders[1].fieldValue).toBe('<sip:bob@biloxi.com>');
     });
+    it('should respect quoted commas', () => {
+        const headerLine = 'Contact: "Doe, \\"Jimmy, Jim\\" John" <sip:john@doe.com>, "Smith, Jane" <sip:jane@smith.com>';
+        const parsedHeaders = parseHeaderLine(headerLine);
+        expect(parsedHeaders.length).toBe(2);
+        expect(parsedHeaders[0].fieldName).toBe('Contact');
+        expect(parsedHeaders[0].fieldValue).toBe('"Doe, \\"Jimmy, Jim\\" John" <sip:john@doe.com>');
+        expect(parsedHeaders[1].fieldName).toBe('Contact');
+        expect(parsedHeaders[1].fieldValue).toBe('"Smith, Jane" <sip:jane@smith.com>');
+    });
     it('should not add parameters if they do not exist', () => {
         const headerLine = 'Route: Alice <sip:alice@atlanta.com>';
         const parsedHeaders = parseHeaderLine(headerLine);


### PR DESCRIPTION
Currently the library fails with quoted commas in a header value:

```
Contact: "Doe, \"Jimmy, Jim\" John" <sip:john@doe.com>, "Smith, Jane" <sip:jane@smith.com>
```

is split into

```json
[
  {
    "fieldName": "Contact",
    "fieldValue": "\"Doe"
  },
  {
    "fieldName": "Contact",
    "fieldValue": "\\\"Jimmy"
  },
  {
    "fieldName": "Contact",
    "fieldValue": "Jim\\\" John\" <sip:john@doe.com>"
  },
  {
    "fieldName": "Contact",
    "fieldValue": "\"Smith"
  },
  {
    "fieldName": "Contact",
    "fieldValue": "Jane\" <sip:jane@smith.com>"
  }
]
```

instead of

```json
[
  {
    "fieldName": "Contact",
    "fieldValue": "\"Doe, \\\"Jimmy, Jim\\\" John\" <sip:john@doe.com>"
  },
  {
    "fieldName": "Contact",
    "fieldValue": "\"Smith, Jane\" <sip:jane@smith.com>"
  }
]
```

This PR uses a simple FSM to parse the header and determine if a comma is inside a quote or not.