### PR TITLE
feat: parse SIPS URIs

### DIFF
--- a/src/__tests__/stringifier.test.ts
+++ b/src/__tests__/stringifier.test.ts
@@ -34,6 +34,36 @@ describe('stringify', () => {
                 const stringified = stringify(exampleRequest);
                 expect(stringified.startsWith('ACK sip:test@google.com SIP/2.0\r\n')).toBe(true);
             });
+            it('should stringify secure SIP', () => {
+                // This request is build based on the example on page 130 of RFC 3261.
+                const exampleRequest = {
+                    method: 'ACK',
+                    requestUri: { user: 'test', host: 'google.com', secure: true },
+                    version: '2.0',
+                    headers: [{
+                        fieldName: 'Via',
+                        fieldValue: 'SIP/2.0/UDP pc33.atlanta.com',
+                        parameters: [{ name: 'branch', value: 'z9hG4bKkjshdyff' }],
+                    }, {
+                        fieldName: 'To',
+                        fieldValue: 'Bob <sip:bob@biloxi.com>',
+                        parameters: [{ name: 'tag', value: '99sa0xk' }],
+                    }, {
+                        fieldName: 'From',
+                        fieldValue: 'Alice <sip:alice@atlanta.com>',
+                        parameters: [{ name: 'tag', value: '88sja8x' }],
+                    }, {
+                        fieldName: 'Max-Forwards', fieldValue: '70'
+                    }, {
+                        fieldName: 'Call-ID', fieldValue: '987asjd97y7atg'
+                    }, {
+                        fieldName: 'CSeq', fieldValue: '986759 ACK'
+                    }],
+                    content: '',
+                };
+                const stringified = stringify(exampleRequest);
+                expect(stringified.startsWith('ACK sips:test@google.com SIP/2.0\r\n')).toBe(true);
+            });
             it('should stringify the startline with a defined port', () => {
                 const exampleRequest = {
                     method: 'ACK',

--- a/src/__tests__/uri.test.ts
+++ b/src/__tests__/uri.test.ts
@@ -11,6 +11,18 @@ describe('parseUri', () => {
             expect(() => parseUri(malformedUri3)).toThrowError('not a valid');
         });
     });
+    describe('secure SIP', () => {
+        it('should parse a secure SIP URI', () => {
+            const secureUri = 'sips:alice@chicago.com';
+            const uri = parseUri(secureUri);
+            expect(uri.secure).toBeTruthy();
+        });
+        it('should parse an unsecure SIP URI', () => {
+            const secureUri = 'sip:alice@chicago.com';
+            const uri = parseUri(secureUri);
+            expect(uri.secure).toBeFalsy();
+        });
+    });
     describe('user', () => {
         it('should parse an alphanumeric username', () => {
             const validUri = 'sip:alice@chicago.com';

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -63,7 +63,7 @@ function isolateContentLines(messageString: string): string[] {
 
 function matchRequestLine(startLine: string) {
     // Matches the method, request URI and SIP version.
-    return startLine.match(/([A-Za-z]+)\s(sip:(?:[\w.-]+@)?[\w\-.]+(?::\d+)?)\sSIP\/(\d\.\d)/);
+    return startLine.match(/([A-Za-z]+)\s(sips?:(?:[\w.-]+@)?[\w\-.]+(?::\d+)?)\sSIP\/(\d\.\d)/);
 }
 
 function matchStatusLine(startLine: string) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,7 @@ export interface SIPResponse {
 }
 
 export interface SipUri {
+    secure?: boolean,
     host: string,
     user?: string,
     port?: number,

--- a/src/uri.ts
+++ b/src/uri.ts
@@ -1,23 +1,26 @@
 import { parseNameValuePairs, stringifyNameValuePairs } from './nameValueParser';
 import { SipUri } from './types';
 
+const SipUriRegexp = /sip(?<secure>s?):(?:(?<user>[^@]+)@)?(?<host>[\w.-]+)(?::?(?<port>\d+))?(?:;(?<params>[\w.\-=;]+))?/u;
+
 export function parseUri(uriString: string): SipUri {
     // Matches the username, the host and optionally a port.
-    const uriMatches = uriString.match(/sip:(?:([\w.]+)@)?([\w.-]+)(?::?(\d+))?(?:;([\w.\-=;]+))?/);
-    if (!uriMatches)
+    const uriMatches = uriString.match(SipUriRegexp);
+    if (!uriMatches || !uriMatches.groups)
         throw new Error('Given string was not a valid URI: ' + uriString);
 
-    const params = parseNameValuePairs(uriMatches[4]);
+    const params = parseNameValuePairs(uriMatches.groups.params);
     return {
-        user: uriMatches[1],
-        host: uriMatches[2],
-        port: uriMatches[3] ? parseInt(uriMatches[3]) : undefined,
+        secure: uriMatches.groups.secure === 's' || undefined,
+        user: uriMatches.groups.user,
+        host: uriMatches.groups.host,
+        port: uriMatches.groups.port ? parseInt(uriMatches.groups.port) : undefined,
         parameters: params.length > 0 ? params : undefined,
     };
 }
 
 export function stringifyUri(uri: SipUri): string {
-    let sipString = 'sip:';
+    let sipString = `sip${uri.secure === true ? 's' : ''}:`;
 
     if (uri.user)
         sipString += `${uri.user}@`;


### PR DESCRIPTION
Currently the library does not allow to parse requests or create responses using SIPS.

This PR adds a boolean parameter `secure` to the `SipUri` interface.
In order to be backwards compatible the parser only sets the value to `true`, when SIPS is detected, and leaves it `undefined` otherwise.

As a bonus the SIP-regex has been refactored to use named groups.