### PR TITLE
fix: accept request-URIs with parameters

### DIFF
--- a/src/__tests__/parser.test.ts
+++ b/src/__tests__/parser.test.ts
@@ -169,6 +169,37 @@ describe('start line', () => {
                 });
             }
         });
+        it('should read a Request-URI with parameters', () => {
+            const registerRequest =
+                'REGISTER sip:alice@atlanta.com;maddr=239.255.255.1;ttl=15 SIP/2.0\r\n' +
+                'Via: SIP/2.0/UDP bobspc.biloxi.com:5060;branch=z9hG4bKnashds7\r\n' +
+                'Max-Forwards: 70\r\n' +
+                'To: Bob <sip:bob@biloxi.com>\r\n' +
+                'From: Bob <sip:bob@biloxi.com>;tag=456248\r\n' +
+                'Call-ID: 843817637684230@998sdasdh09\r\n' +
+                'CSeq: 1826 REGISTER\r\n' +
+                'Contact: <sip:bob@192.0.2.4>\r\n' +
+                'Expires: 7200\r\n' +
+                'Content-Length: 0\r\n\r\n';
+            const parsed = parse(registerRequest);
+            expect('requestUri' in parsed);
+            if ('requestUri' in parsed) {
+                expect(parsed.requestUri).toEqual({
+                    user: 'alice',
+                    host: 'atlanta.com',
+                    parameters: [
+                        {
+                            name: 'maddr',
+                            value: '239.255.255.1'
+                        },
+                        {
+                            name: 'ttl',
+                            value: '15'
+                        }
+                    ]
+                });
+            }
+        });
         it.todo('should handle a user with unescaped, allowed special characters');
         it.todo('should handle a user with escaped special characters');
         it.todo('should throw an error for a version other than 2.0');


### PR DESCRIPTION
Currently the initial classifier in the message parser (`matchRequestLine`) does not accept request-URIs containing parameters, even though they are well documented in the [RFC 3261, section 19.1.1](https://www.rfc-editor.org/rfc/rfc3261.html#section-19.1.1) and the URI-parser `parseUri` does.

Since the task of regular expressions in the `parse` method only seems to be to determine whether the message is a request or a status response, I have removed any complex URI matching at this stage, because `parseUri` does it anyways later on.

Similar to the previous PRs I have also refactored the regular expressions to use named groups, as this allows to (potentially) modify them down the line, without having to keep track if the groups' indices.

I have  deliberately left out the handling of headers, even though they are also defined in the RFC, because this would open quite a nasty can of worms. These headers would have to be incorporated into the parsed header lines, dealing with such edge cases like a `body` header replacing the `message-body` of a request. I believe it is justified, since headers are allowed neither in request-URIs, nor in the `to` and `from` fields. (cf. Table 1 in the RFS's section)